### PR TITLE
feat: dynamic import of catechism data

### DIFF
--- a/app/components/catechism-list/index.hbs
+++ b/app/components/catechism-list/index.hbs
@@ -3,7 +3,7 @@
     Available catechisms
   </h1>
   <ul class='flex-col space-y-8'>
-    {{#each-in this.catechisms as |id catechism|}}
+    {{#each-in this.catechisms as |id title|}}
       <li class="block my-2">
         <LinkTo
           @route='catechism'
@@ -11,7 +11,7 @@
           class='py-2 px-6 border-2 border-cyan-800 bg-transparent text-cyan-800 font-bold whitespace-nowrap'
           data-catechism-link
         >
-          {{catechism.metadata.title}}
+          {{title}}
         </LinkTo>
       </li>
     {{/each-in}}

--- a/app/data/catechisms/for-young-children.ts
+++ b/app/data/catechisms/for-young-children.ts
@@ -1,6 +1,6 @@
 import type { CatechismData } from '../types';
 
-export const ForYoungChildren: CatechismData = {
+const ForYoungChildren: CatechismData = {
   metadata: {
     title: 'Catechism For Young Children',
     alternativeTitles: [],
@@ -772,3 +772,5 @@ export const ForYoungChildren: CatechismData = {
     },
   ],
 };
+
+export default ForYoungChildren;

--- a/app/data/catechisms/heidelberg.ts
+++ b/app/data/catechisms/heidelberg.ts
@@ -1,6 +1,6 @@
 import type { CatechismData } from '../types';
 
-export const Heidelberg: CatechismData = {
+const Heidelberg: CatechismData = {
   metadata: {
     title: 'Heidelberg Catechism',
     alternativeTitles: [
@@ -2878,3 +2878,5 @@ export const Heidelberg: CatechismData = {
     },
   ],
 };
+
+export default Heidelberg;

--- a/app/data/catechisms/index.ts
+++ b/app/data/catechisms/index.ts
@@ -1,17 +1,9 @@
-import { WestminsterShorter } from './westminster-shorter';
-import { WestminsterLonger } from './westminster-longer';
-import { ForYoungChildren } from './for-young-children';
-import { Heidelberg } from './heidelberg';
-import { NewCity } from './new-city';
-import { Puritan } from './puritan';
-import { Keachs } from './keachs';
-
 export const catechisms = {
-  'westminster-shorter': WestminsterShorter,
-  'westminster-longer': WestminsterLonger,
-  'for-young-children': ForYoungChildren,
-  heidelberg: Heidelberg,
-  'new-city': NewCity,
-  keachs: Keachs,
-  puritan: Puritan,
+  'westminster-shorter': 'Westminster Shorter Catechism',
+  'westminster-longer': 'Westminster Larger Catechism',
+  'for-young-children': 'Catechism For Young Children',
+  heidelberg: 'Heidelberg Catechism',
+  'new-city': 'New City Catechism',
+  keachs: "Keach's Catechism",
+  puritan: 'Puritan Catechism',
 } as const;

--- a/app/data/catechisms/keachs.ts
+++ b/app/data/catechisms/keachs.ts
@@ -1,6 +1,6 @@
 import type { CatechismData } from '../types';
 
-export const Keachs: CatechismData = {
+const Keachs: CatechismData = {
   metadata: {
     title: "Keach's Catechism",
     alternativeTitles: ['Baptist Catechism'],
@@ -1731,3 +1731,5 @@ export const Keachs: CatechismData = {
     },
   ],
 };
+
+export default Keachs;

--- a/app/data/catechisms/new-city.ts
+++ b/app/data/catechisms/new-city.ts
@@ -523,7 +523,7 @@ const COMMENTARY = {
   ],
 };
 
-export const NewCity: CatechismData = {
+const NewCity: CatechismData = {
   metadata: {
     title: 'New City Catechism',
     alternativeTitles: ['52 Questions and Answers for Our Hearts and Minds'],
@@ -1676,3 +1676,5 @@ export const NewCity: CatechismData = {
     },
   ],
 };
+
+export default NewCity;

--- a/app/data/catechisms/puritan.ts
+++ b/app/data/catechisms/puritan.ts
@@ -1,6 +1,6 @@
 import type { CatechismData } from '../types';
 
-export const Puritan: CatechismData = {
+const Puritan: CatechismData = {
   metadata: {
     title: 'Puritan Catechism',
     alternativeTitles: [],
@@ -521,3 +521,5 @@ export const Puritan: CatechismData = {
     },
   ],
 };
+
+export default Puritan;

--- a/app/data/catechisms/westminster-longer.ts
+++ b/app/data/catechisms/westminster-longer.ts
@@ -1,6 +1,6 @@
 import type { CatechismData } from '../types';
 
-export const WestminsterLonger: CatechismData = {
+const WestminsterLonger: CatechismData = {
   metadata: {
     title: 'Westminster Larger Catechism',
     alternativeTitles: [],
@@ -7335,3 +7335,5 @@ export const WestminsterLonger: CatechismData = {
     },
   ],
 };
+
+export default WestminsterLonger;

--- a/app/data/catechisms/westminster-shorter.ts
+++ b/app/data/catechisms/westminster-shorter.ts
@@ -1,6 +1,6 @@
 import type { CatechismData } from '../types';
 
-export const WestminsterShorter: CatechismData = {
+const WestminsterShorter: CatechismData = {
   metadata: {
     title: 'Westminster Shorter Catechism',
     year: '1647',
@@ -1569,3 +1569,5 @@ export const WestminsterShorter: CatechismData = {
     },
   ],
 };
+
+export default WestminsterShorter;

--- a/app/data/index.ts
+++ b/app/data/index.ts
@@ -2,4 +2,4 @@ export { catechisms } from './catechisms';
 
 export type { CatechismData, CatechismItem } from './types';
 
-export { isCatechism, getCatechism, getQuestion } from './utils';
+export { isCatechismId, getCatechism, getQuestion } from './utils';

--- a/app/data/types.ts
+++ b/app/data/types.ts
@@ -1,6 +1,6 @@
 import type { catechisms } from './catechisms';
 
-export type Catechism = keyof typeof catechisms;
+export type CatechismId = keyof typeof catechisms;
 
 export interface CatechismData {
   metadata: {

--- a/app/data/utils.ts
+++ b/app/data/utils.ts
@@ -1,13 +1,15 @@
 import { catechisms } from './catechisms';
-import type { Catechism, CatechismData } from './types';
+import type { CatechismId, CatechismData } from './types';
 
-export function isCatechism(str: string): str is Catechism {
+export function isCatechismId(str: string): str is CatechismId {
   return Object.keys(catechisms).includes(str);
 }
 
-export async function getCatechism(str: string) {
-  if (isCatechism(str)) {
-    return catechisms[str];
+export async function getCatechism(id: string): Promise<CatechismData> {
+  if (isCatechismId(id)) {
+    const module = await import(`./catechisms/${id}`);
+
+    return module.default;
   }
 
   throw new Error('404');

--- a/app/routes/catechism.ts
+++ b/app/routes/catechism.ts
@@ -2,13 +2,13 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { getCatechism } from 'catechesis/data';
 
-import type { Catechism } from 'catechesis/data/types';
+import type { CatechismId } from 'catechesis/data/types';
 import type HeadDataService from 'catechesis/services/head-data';
 
 type Resolved<P> = P extends Promise<infer T> ? T : P;
 export type CatechismRouteModel = Resolved<ReturnType<CatechismRoute['model']>>;
 export interface CatechismRouteParams {
-  catechism: Catechism;
+  catechism: CatechismId;
 }
 export default class CatechismRoute extends Route {
   @service declare headData: HeadDataService;

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 import stored from 'catechesis/decorators/stored';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import type { Catechism } from 'catechesis/data/types';
+import type { CatechismId } from 'catechesis/data/types';
 import type RouterService from '@ember/routing/router-service';
 import type Transition from '@ember/routing/-private/transition';
 
@@ -11,7 +11,7 @@ export default class SettingsService extends Service {
 
   @stored alwaysShowAnswers = false;
   @stored pickUpWhereYouLeftOff = false;
-  @stored lastQuestion?: { catechism: Catechism; question: string };
+  @stored lastQuestion?: { catechism: CatechismId; question: string };
 
   @action doPickupWhereYouLeftOff(transition: Transition) {
     let toCatechism = transition.to.find(({ name }) => name === 'catechism')

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -67,6 +67,7 @@ module.exports = function (defaults) {
   const compiledApp = require('@embroider/compat').compatBuild(app, Webpack, {
     staticAddonTestSupportTrees: true,
     staticAddonTrees: true,
+    staticAppPaths: ['data'],
     staticHelpers: true,
     staticModifiers: true,
     staticComponents: true,


### PR DESCRIPTION
Uses embroider staticAppPaths and dynamic import via ember-auto-import to generate js chunks for each catechism data and dynamically import catechism data as it is accessed. 

This lightens the JS payload on initial load and means that users only need to load the catechism data they need. Dynamic import allows us to keep the catechism data in Typescript and benefit from TS and Glint guarantees, which would not be possible if the data were stored as JSON and fetched over http.