### PR TITLE
Fix: don't load scripture if there are no proofs

### DIFF
--- a/app/routes/catechism/question/scripture.ts
+++ b/app/routes/catechism/question/scripture.ts
@@ -66,7 +66,7 @@ export default class ScriptureRoute extends Route {
 
     const scripture = proofsToScriptures(questionModel.current.proofs);
 
-    if (this.fastboot.isFastBoot) return scripture;
+    if (this.fastboot.isFastBoot || scripture.length === 0) return scripture;
 
     const verseQuery = scripturesToQuery(scripture);
 


### PR DESCRIPTION
For catechism questions with no proofs we still attempted to load verses from the ESV api.
Since there are no verses to query in this case the ESV api would return an error.
Since we have to proofs to load verses for we can early return before attempting to load verses from the ESV api.

Fixes #38 